### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
 
+        timeout-minutes: 60
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - name: Checkout
               uses: actions/checkout@v2


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259